### PR TITLE
Remove certain usages of hsc2hs due to cross-compilation

### DIFF
--- a/hsrc_lib/Database/LMDB/Raw.hsc
+++ b/hsrc_lib/Database/LMDB/Raw.hsc
@@ -144,8 +144,6 @@ import Data.Function (on)
 import Data.Maybe (isNothing)
 import Data.IORef
 
-#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
-
 -- FFI
 --  'safe': higher overhead, thread juggling, allows callbacks into Haskell
 --  'unsafe': lower overhead, reduced concurrency, no callbacks into Haskell
@@ -262,7 +260,13 @@ lmdb_version = LMDB_Version
     { v_major = #const MDB_VERSION_MAJOR
     , v_minor = #const MDB_VERSION_MINOR
     , v_patch = #const MDB_VERSION_PATCH
-    , v_text  = #const_str MDB_VERSION_STRING
+    , v_text  =
+        -- #const_str is not supported when cross compiling
+        -- #const_str MDB_VERSION_STRING
+        "LMDB "
+          <> show (v_major lmdb_version) <> "."
+          <> show (v_minor lmdb_version) <> "."
+          <> show (v_patch lmdb_version)
     }
 
 


### PR DESCRIPTION
 - `#let` is not supported when cross-compiling, but `#alignment` is a
   native keyword in (recent versions of) hsc2hs.

 - `#const_str` is also not supported when cross-compiling, but its
   only use is not very important.

Also see https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/utils.html#cross-compilation