### PR TITLE
Add pkg-config cabal flag

### DIFF
--- a/lmdb.cabal
+++ b/lmdb.cabal
@@ -31,6 +31,14 @@ Source-repository head
   type: git
   location: http://github.com/dmbarbour/haskell-lmdb.git
 
+Flag use-pkg-config
+    Description:
+        Use pkg-config to find LMDB
+    Default:
+        False
+    Manual:
+        True
+
 Library
   hs-Source-Dirs: hsrc_lib
   default-language: Haskell2010
@@ -45,6 +53,9 @@ Library
 
   include-dirs:
   c-sources:
-  extra-libraries: lmdb
+  if flag(use-pkg-config)
+      pkgconfig-depends: lmdb
+  else
+      extra-libraries: lmdb
 
   ghc-options: -Wall -fprof-auto


### PR DESCRIPTION
In the same style as the HsOpenSSL package does it, this allows to
easily integrate with pkg-config.